### PR TITLE
Adds support for api access with aceess_token

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 sudo: false
 python:
+  - "3.6"
   - "3.5"
-  - "3.5-dev"
 # command to install dependencies
 install:
   - pip install -r requirements.txt

--- a/appknox/cli.py
+++ b/appknox/cli.py
@@ -89,7 +89,7 @@ def cli(ctx, verbose, profile):
 
     logging.basicConfig(level=ctx.obj['LOG_LEVEL'])
 
-    if ctx.invoked_subcommand in ['login', 'logout']:
+    if ctx.invoked_subcommand in ['login']:
         return
 
     profile = get_profile(profile)
@@ -173,6 +173,10 @@ def logout(ctx):
     """
     profile = ctx.obj['PROFILE']
     success = remove_profile(profile)
+
+    client = ctx.obj['CLIENT']
+    client.revoke_access_token()
+
     if success:
         echo('Logged out')
     else:

--- a/appknox/cli.py
+++ b/appknox/cli.py
@@ -2,14 +2,12 @@
 
 
 import configparser
-import datetime
 import logging
 import os
 import requests
 import sys
 import tabulate
 import time
-from datetime import datetime as dt
 
 import click
 from click import echo
@@ -21,7 +19,6 @@ from appknox.mapper import Analysis, File, Project, User, Vulnerability
 
 CONFIG_FILE = os.path.expanduser('~/.config/appknox.ini')
 DEFAULT_PROFILE = 'default'
-TOKEN_EXPIRY_DAYS = 7
 
 config = configparser.ConfigParser()
 config.read(CONFIG_FILE)
@@ -73,14 +70,6 @@ def remove_profile(name):
     return result
 
 
-def is_expired(profile):
-    timestamp = int(profile.get('timestamp', 0))
-    logged = dt.utcfromtimestamp(timestamp)
-    now = dt.now()
-    expiry = datetime.timedelta(days=TOKEN_EXPIRY_DAYS)
-    return logged + expiry < now
-
-
 @click.group()
 @click.option('-v', '--verbose', count=True, help='Specify log verbosity.')
 @click.option('-n', '--profile', default=DEFAULT_PROFILE)
@@ -108,13 +97,15 @@ def cli(ctx, verbose, profile):
     if not profile:
         echo('Not logged in')
         sys.exit(1)
-    if is_expired(profile):
-        echo('Your session is expired. Login again')
+
+    if not profile.get('access_token', None):
+        echo('Access token doesn\'t exist. Login again')
         sys.exit(1)
 
     ctx.obj['CLIENT'] = Appknox(
         username=profile['username'], user_id=profile['user_id'],
-        token=profile['token'], host=profile['host'],
+        token=profile['token'], access_token=profile['access_token'],
+        host=profile['host']
     )
 
 
@@ -155,6 +146,7 @@ def login(ctx, username, password, host):
         'username': username,
         'user_id': client.user_id,
         'token': client.token,
+        'access_token': client.access_token,
         'host': host,
         'timestamp': str(int(time.time())),
     }

--- a/appknox/client.py
+++ b/appknox/client.py
@@ -100,6 +100,9 @@ class Appknox(object):
         )
 
     def generate_access_token(self):
+        """
+        Generates personal access token
+        """
         access_token = requests.post(
             urljoin(self.host, 'api/personaltokens'),
             auth=(self.user_id, self.token),
@@ -110,6 +113,25 @@ class Appknox(object):
             }
         )
         return mapper(PersonalToken, access_token.json())
+
+    def revoke_access_token(self):
+        """
+        Revokes existing personal access token
+        """
+        resp = requests.get(
+            urljoin(self.host, 'api/personaltokens?key=' + self.access_token),
+            auth=(self.user_id, self.token)
+        )
+        resp_json = resp.json()
+        personal_token = next((p for p in resp_json.get('data')), None)
+        if not personal_token:
+            return
+
+        token_id = personal_token['id']
+        return requests.delete(
+            urljoin(self.host, 'api/personaltokens/' + token_id),
+            auth=(self.user_id, self.token)
+        )
 
     def get_user(self, user_id: int) -> User:
         """

--- a/appknox/mapper.py
+++ b/appknox/mapper.py
@@ -43,3 +43,8 @@ Vulnerability = namedtuple(
     'Vulnerability',
     ['name', 'description', 'intro', 'compliant', 'non_compliant']
 )
+
+PersonalToken = namedtuple(
+    'AccessToken',
+    ['name', 'key']
+)

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,3 +20,6 @@ all_files = 1
 [upload_sphinx]
 upload-dir = docs/build/html
 
+[flake8]
+exclude =
+    sphinx-docs


### PR DESCRIPTION
- Adds support for API calls with access token (new personal token gets created on login, stored in profile, and is revoked on logout)
- Removes expiry check
- Replaces **slumber** with custom requests wrapper (slumber doesn't support custom headers)
---
- Removes python `3.5-dev`, instead add `3.6` in travis.yml
- Excludes `sphinx-docs/` from flake8