### PR TITLE
Watson requirements

### DIFF
--- a/appknox/client.py
+++ b/appknox/client.py
@@ -176,11 +176,15 @@ class Appknox(object):
 
         return initial_data
 
-    def get_projects(self) -> List[Project]:
+    def get_projects(
+        self, platform: int = -1, package_name: str = ''
+    ) -> List[Project]:
         """
         List projects for currently authenticated user
         """
-        projects = self.api.projects().get(limit=-1)
+        projects = self.api.projects().get(
+            limit=-1, platform=platform, query=package_name
+        )
 
         return self.paginated_data(projects, Project)
 

--- a/appknox/mapper.py
+++ b/appknox/mapper.py
@@ -30,7 +30,7 @@ Project = namedtuple(
 
 File = namedtuple(
     'File',
-    ['id', 'name', 'version', 'version_code']
+    ['id', 'name', 'version', 'version_code', 'static_scan_progress']
 )
 
 Analysis = namedtuple(
@@ -41,7 +41,7 @@ Analysis = namedtuple(
 
 Vulnerability = namedtuple(
     'Vulnerability',
-    ['name', 'description', 'intro', 'compliant', 'non_compliant']
+    ['name', 'description', 'intro', 'compliant', 'non_compliant', 'types']
 )
 
 PersonalToken = namedtuple(


### PR DESCRIPTION
- `get_projects` now accepts `platform` and `package_name` (only for API, not supported by CLI yet)
- new field for File mapper: `static_scan_progress`
- new field for Vulnerability mapper: `types`