### PR TITLE
Rescan method in client will use v2 of API and rescan command is removed

### DIFF
--- a/appknox/cli.py
+++ b/appknox/cli.py
@@ -341,17 +341,6 @@ def owasp(ctx, owasp_id):
 #         sys.exit(1)
 
 
-@cli.command()
-@click.argument('file_id')
-@click.pass_context
-def rescan(ctx, file_id):
-    """
-    Start rescanning a file
-    """
-    client = ctx.obj['CLIENT']
-    client.rescan(file_id)
-
-
 @cli.command('switch_organization')
 @click.argument('organization_id')
 @click.pass_context

--- a/appknox/client.py
+++ b/appknox/client.py
@@ -10,7 +10,8 @@ from urllib.parse import urljoin
 
 from appknox.exceptions import (
     OneTimePasswordError, CredentialError, AppknoxError,
-    OrganizationError, UploadError
+    OrganizationError, UploadError, SubmissionNotFound,
+    SubmissionError, SubmissionFileTimeoutError, RescanError
 )
 from appknox.mapper import (
     mapper_json_api, mapper_drf_api, Analysis, File, Project, User,
@@ -410,7 +411,7 @@ class Appknox(object):
         pcidss = self.drf_api['v2/pcidsses'](pcidss_id).get()
         return mapper_drf_api(PCIDSS, pcidss)
 
-    def upload_file(self, file_data: str):
+    def upload_file(self, file_data: str) -> int:
         """
         Upload and scan a package and returns the file_id
 
@@ -431,9 +432,14 @@ class Appknox(object):
             )
         )
         submission_id = response2['submission_id']
-        return self.get_file_from_submission_id(submission_id)
+        try:
+            file_id = self.poll_for_file_from_submission_id(submission_id)
+        except (SubmissionNotFound, SubmissionError):
+            raise UploadError('Something went wrong, try uploading the\
+             file again.')
+        return file_id
 
-    def get_file_from_submission_id(self, submission_id: int):
+    def poll_for_file_from_submission_id(self, submission_id: int) -> int:
         """
         Using the submission id, keep checking its status.
         Returns file instance when it's available
@@ -448,15 +454,13 @@ class Appknox(object):
         while (file is None):
             submission = self.drf_api.submissions(submission_id).get()
             if submission.get('detail') == 'Not found.':
-                raise UploadError(
-                    'Something went wrong, try uploading the file again.')
+                raise SubmissionNotFound()
             submission_obj = mapper_drf_api(Submission, submission)
             file = submission_obj.file
             if submission_obj.reason:
-                raise UploadError(submission_obj.reason)
+                raise SubmissionError(submission_obj.reason)
             if time.time() > timeout:
-                raise RuntimeError(
-                    'Request timed out, try uploading the file again.')
+                raise SubmissionFileTimeoutError()
         return file
 
     def recent_uploads(self) -> List[Submission]:
@@ -467,13 +471,13 @@ class Appknox(object):
 
         return self.paginated_drf_data(submissions, Submission)[0:10]
 
-    def rescan(self, file_id: int):
+    def rescan(self, file_id: int) -> int:
         """
         Start a rescan for a file id
 
         :param filed_id: File ID
 
-        :return: The file IF
+        :return: The ID of the File created in rescan
         """
         endpoint = 'v2/files/{}/rescan'.format(file_id)
         response = self.drf_api[endpoint]().post(
@@ -481,7 +485,11 @@ class Appknox(object):
 
         )
         submission_id = response['submission_id']
-        return self.get_file_from_submission_id(submission_id)
+        try:
+            file = self.poll_for_file_from_submission_id(submission_id)
+        except (SubmissionNotFound, SubmissionError):
+            raise RescanError('Something went wrong, retry rescan')
+        return file
 
     # def get_report(
     #         self, file_id, format: str = 'json', language: str = 'en') ->

--- a/appknox/client.py
+++ b/appknox/client.py
@@ -444,7 +444,7 @@ class Appknox(object):
          :return: The File ID
         """
         file = None
-        timeout= time.time() + 10
+        timeout = time.time() + 10
         while (file is None):
             submission = self.drf_api.submissions(submission_id).get()
             if submission.get('detail') == 'Not found.':

--- a/appknox/client.py
+++ b/appknox/client.py
@@ -430,9 +430,21 @@ class Appknox(object):
                 url=response['url']
             )
         )
-        file = None
-        timeout = time.time() + 10
         submission_id = response2['submission_id']
+        return self.get_file_from_submission_id(submission_id)
+
+    def get_file_from_submission_id(self, submission_id: int):
+        """
+        Using the submission id, keep checking its status.
+        Returns file instance when it's available
+
+        :param submission_id: The ID of the submission object
+         created for the scan
+
+         :return: The File ID
+        """
+        file = None
+        timeout= time.time() + 10
         while (file is None):
             submission = self.drf_api.submissions(submission_id).get()
             if submission.get('detail') == 'Not found.':
@@ -460,13 +472,16 @@ class Appknox(object):
         Start a rescan for a file id
 
         :param filed_id: File ID
+
+        :return: The file IF
         """
         endpoint = 'v2/files/{}/rescan'.format(file_id)
         response = self.drf_api[endpoint]().post(
             data=dict()
 
         )
-        return response
+        submission_id = response['submission_id']
+        return self.get_file_from_submission_id(submission_id)
 
     # def get_report(
     #         self, file_id, format: str = 'json', language: str = 'en') ->

--- a/appknox/client.py
+++ b/appknox/client.py
@@ -461,11 +461,12 @@ class Appknox(object):
 
         :param filed_id: File ID
         """
-        self.drf_api['rescan']().post(
-            data=dict(
-                file_id=file_id,
-            )
+        endpoint = 'v2/files/{}/rescan'.format(file_id)
+        response = self.drf_api[endpoint]().post(
+            data=dict()
+
         )
+        return response
 
     # def get_report(
     #         self, file_id, format: str = 'json', language: str = 'en') ->

--- a/appknox/exceptions.py
+++ b/appknox/exceptions.py
@@ -29,3 +29,19 @@ class OrganizationError(AppknoxError):
 
 class UploadError(AppknoxError):
     pass
+
+
+class SubmissionNotFound(AppknoxError):
+    pass
+
+
+class SubmissionError(AppknoxError):
+    pass
+
+
+class SubmissionFileTimeoutError(AppknoxError):
+    pass
+
+
+class RescanError(AppknoxError):
+    pass


### PR DESCRIPTION
1. The rescan method in client now uses v2 of rescan API which now points at `/api/v2/<file_id>/rescan`.
2. The `rescan` command defined in cli.py file has been removed. So `appknox rescan <file_id>` command will no longer work.